### PR TITLE
feat: startTimer return function should return duration value

### DIFF
--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -136,7 +136,8 @@ class Histogram {
 	 * @example
 	 * var end = histogram.startTimer();
 	 * makeExpensiveXHRRequest(function(err, res) {
-	 *	end(); //Observe the duration of expensiveXHRRequest
+	 *	const duration = end(); //Observe the duration of expensiveXHRRequest and returns duration in seconds
+	 *      console.log('Duration', duration);
 	 * });
 	 */
 	startTimer(labels) {
@@ -162,13 +163,16 @@ function startTimer(startLabels) {
 		const start = process.hrtime();
 		return endLabels => {
 			const delta = process.hrtime(start);
+			const value = delta[0] + delta[1] / 1e9;
 			this.observe(
 				Object.assign({}, startLabels, endLabels),
-				delta[0] + delta[1] / 1e9
+				value
 			);
+			return value;
 		};
 	};
 }
+
 function validateInput(name, help, labels) {
 	if (!help) {
 		throw new Error('Missing mandatory help parameter');


### PR DESCRIPTION
Hi I have a use case in which this value its really useful to me for logging purposes, if we return this value in the helper, I could save a few lines of code and maybe this seems quite straightforward.